### PR TITLE
fix: develop 태그 이미지 빌드 추가

### DIFF
--- a/.github/workflows/build-client-image.yml
+++ b/.github/workflows/build-client-image.yml
@@ -43,3 +43,9 @@ jobs:
 
           docker build -t $IMAGE:$TAG .
           docker push $IMAGE:$TAG
+          
+          # develop 브랜치일 때 develop 태그로도 푸시
+          if [ "${{ github.ref }}" == "refs/heads/develop" ]; then
+            docker tag $IMAGE:$TAG $IMAGE:develop
+            docker push $IMAGE:develop
+          fi


### PR DESCRIPTION
- develop 브랜치일 때 develop 태그로도 이미지 푸시
- 매니페스트 워크플로우의 develop 태그 폴백 지원