### PR TITLE
feat(admin): 테스트 데이터 페이지 선생님 카운트 추가

### DIFF
--- a/src/features/admin/components/testdata/TestDataPage.tsx
+++ b/src/features/admin/components/testdata/TestDataPage.tsx
@@ -53,7 +53,7 @@ export function TestDataPage() {
               <p>총 레코드: {summary.totalCount}건</p>
             </div>
             {summary.counts && (
-              <div className="border-border mt-4 grid grid-cols-2 gap-3 border-t pt-4 sm:grid-cols-3 lg:grid-cols-7">
+              <div className="border-border mt-4 grid grid-cols-2 gap-3 border-t pt-4 sm:grid-cols-4 lg:grid-cols-8">
                 <div className="bg-muted rounded-lg p-3 text-center">
                   <p className="text-muted-foreground text-xs">기관</p>
                   <p className="text-foreground text-xl font-bold">{summary.counts.organizations}</p>
@@ -61,6 +61,10 @@ export function TestDataPage() {
                 <div className="bg-muted rounded-lg p-3 text-center">
                   <p className="text-muted-foreground text-xs">강의</p>
                   <p className="text-foreground text-xl font-bold">{summary.counts.lectures}</p>
+                </div>
+                <div className="bg-muted rounded-lg p-3 text-center">
+                  <p className="text-muted-foreground text-xs">선생님</p>
+                  <p className="text-foreground text-xl font-bold">{summary.counts.teachers}</p>
                 </div>
                 <div className="bg-muted rounded-lg p-3 text-center">
                   <p className="text-muted-foreground text-xs">회원</p>
@@ -113,8 +117,9 @@ export function TestDataPage() {
         </div>
 
         <p className="text-muted-foreground mt-4 text-sm">
-          * 테스트 데이터는 2개의 기관, 4개의 강의, 17명의 회원(기관담당자 2명 + 일반회원 15명), 60개의 수료증, 60개의
-          리뷰, 10개의 설문조사, 6개의 배너(대배너 1, 중배너 2, 소배너 3)로 구성됩니다.
+          * 테스트 데이터는 3개의 기관(승인 2 + 대기 1), 4개의 강의(승인 3 + 대기 1), 10명의 선생님, 18명의 회원(기관담당자
+          3명 + 일반회원 15명), 60개의 수료증, 60개의 리뷰(승인 59 + 대기 1), 10개의 설문조사, 8개의 배너(대배너 3, 중배너
+          2, 소배너 3)로 구성됩니다.
         </p>
       </div>
     </div>


### PR DESCRIPTION
## 📋 PR 요약

테스트 데이터 관리 페이지에 선생님 카운트를 표시하고 설명 텍스트를 최신화합니다.

## 🔗 관련 이슈

closes #235

## 📝 변경 사항

- 선생님 카운트 카드 추가 (grid 7열 → 8열로 변경)
- 설명 텍스트 업데이트:
  - 3개 기관 (승인 2 + 대기 1)
  - 4개 강의 (승인 3 + 대기 1)
  - 10명 선생님
  - 18명 회원 (기관담당자 3명 + 일반회원 15명)
  - 60개 리뷰 (승인 59 + 대기 1)
  - 8개 배너 (대배너 3, 중배너 2, 소배너 3)

## 💬 리뷰어에게 (선택)

서버 PR과 함께 머지해주세요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)