### PR TITLE
fix: update CMD path to use standalone server.js

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,5 +49,6 @@ USER nextjs
 
 EXPOSE 3000
 
-CMD ["node", "server.js"]
+CMD ["node", ".next/standalone/server.js"]
+
 


### PR DESCRIPTION
- Change CMD from server.js to .next/standalone/server.js
- Fix Next.js standalone build execution path