### PR TITLE
refactor: change Dockerfile from standalone to standard Next.js build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,22 +33,19 @@ FROM base AS runner
 WORKDIR /app
 
 ENV NODE_ENV=production
-ENV NEXT_TELEMETRY_DISABLED=1
 ENV PORT=3000
 ENV HOSTNAME=0.0.0.0
+ENV NEXT_TELEMETRY_DISABLED=1
 
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
 
 # Next.js 빌드 결과물 복사
+COPY --from=builder /app/package.json ./package.json
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/.next ./.next
 COPY --from=builder /app/public ./public
-COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
-COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
-
-USER nextjs
 
 EXPOSE 3000
 
-CMD ["node", ".next/standalone/server.js"]
-
-
+CMD ["npm", "run", "start"]


### PR DESCRIPTION
- Switch from standalone build to standard Next.js build
- Copy package.json, node_modules, and .next directory
- Change CMD to use npm run start instead of standalone server
- Remove USER nextjs directive
- Reorder environment variables