### PR TITLE
fix: develop 브랜치에서 :develop 가변 태그 제거 및 워크플로우 이름 수정

### DIFF
--- a/.github/workflows/build-client-image.yml
+++ b/.github/workflows/build-client-image.yml
@@ -31,7 +31,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: minji-yoon
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build & Push Image
@@ -39,11 +39,14 @@ jobs:
           IMAGE=ghcr.io/sw-campus/sw-campus-client
 
           if [ "${{ github.ref }}" = "refs/heads/develop" ]; then
-            TAG=dev-${{ github.sha }}
+            TAG=RHSA-${{ github.sha }}
+            echo "Building DEV image with tag $TAG"
             docker build -t $IMAGE:$TAG .
             docker push $IMAGE:$TAG
-          else
+
+          elif [ "${{ github.ref }}" = "refs/heads/main" ]; then
             TAG=${{ steps.version.outputs.version_tag }}
+            echo "Building RELEASE image with tag $TAG"
             docker build -t $IMAGE:$TAG .
             docker push $IMAGE:$TAG
           fi


### PR DESCRIPTION
변경 사항:
- 워크플로우 이름: Build AI Image → Build Client Image
- IMAGE: sw-campus-ai → sw-campus-client (버그 수정)
- develop 브랜치에서 :develop 태그 push 제거
- develop은 dev-<sha> immutable 태그만 사용
- main 브랜치는 v<version> 태그 사용
- env 위치 정리

이유:
- :develop 가변 태그는 이미지 내용이 예기치 않게 변경될 수 있음
- 팀원마다 서로 다른 이미지를 보게 되는 문제 방지
- immutable 태그만 사용하여 안정성 향상

변경 파일:
- .github/workflows/build-client-image.yml