### PR TITLE
fix(ci): release 워크플로우 push 에러 수정

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -16,6 +16,10 @@ permissions:
   contents: write
   packages: write
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build:
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
@@ -27,6 +31,7 @@ jobs:
         with:
           token: ${{ secrets.RELEASE }}
           fetch-depth: 0
+          ref: main
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -95,7 +100,10 @@ jobs:
           # Commit version bump
           git add package.json
           git commit -m "chore: bump version to ${{ steps.version.outputs.version }} [skip ci]"
-          git push
+
+          # Pull latest changes and rebase before push
+          git pull --rebase origin main
+          git push origin main
 
           # Create and push tag (delete if exists)
           git tag -d "$VERSION_TAG" 2>/dev/null || true


### PR DESCRIPTION
## Summary
- CI release 워크플로우에서 발생하던 non-fast-forward push 에러 수정
- Docker 빌드 중 main 브랜치에 새 커밋이 추가되면 push 실패하던 문제 해결

## Changes
1. `concurrency` 설정 추가 - 동시 실행 방지
2. `ref: main` 추가 - 항상 최신 main checkout
3. `git pull --rebase origin main` 추가 - push 전 원격 변경사항 반영

## Test plan
- [ ] develop 머지 후 main 머지
- [ ] main push 시 release 워크플로우 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)