### PR TITLE
refactor: 장바구니를 AI 심층 비교로 명칭 변경

### DIFF
--- a/src/components/layout/header/Header.tsx
+++ b/src/components/layout/header/Header.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
-import { BsCart4 } from 'react-icons/bs'
+import { PiRobotDuotone } from 'react-icons/pi'
 import { FiLogIn, FiUser, FiMenu, FiLogOut } from 'react-icons/fi'
 
 import { HeaderIconAction } from '@/components/layout/header/HeaderIconAction'
@@ -138,8 +138,8 @@ export default function Header({
             </HeaderIconAction>
 
             {userType !== 'ADMIN' && userType !== 'ORGANIZATION' && (
-              <HeaderIconAction kind="link" ariaLabel="위시리스트" tooltip="장바구니" href="/cart/compare">
-                <BsCart4 />
+              <HeaderIconAction kind="link" ariaLabel="AI 심층 비교" tooltip="AI 심층 비교" href="/cart/compare">
+                <PiRobotDuotone />
               </HeaderIconAction>
             )}
           </>

--- a/src/components/layout/header/LogoutDialog.tsx
+++ b/src/components/layout/header/LogoutDialog.tsx
@@ -25,7 +25,7 @@ export function LogoutDialog({ open, onOpenChange, onConfirm, confirmDisabled, h
         <DialogHeader className="gap-5">
           <DialogTitle>로그아웃</DialogTitle>
           <DialogDescription>
-            {hasCartItems ? '장바구니에 있는 항목은 7일간 유지됩니다.' : '로그아웃 하시겠습니까?'}
+            {hasCartItems ? 'AI 심층 비교에 있는 항목은 7일간 유지됩니다.' : '로그아웃 하시겠습니까?'}
           </DialogDescription>
         </DialogHeader>
 

--- a/src/features/cart/components/FloatingCart.tsx
+++ b/src/features/cart/components/FloatingCart.tsx
@@ -59,12 +59,12 @@ export default function FloatingCart() {
             ))}
           </div>
 
-          {/* 우측 화살표 */}
+          {/* 과정비교 버튼 */}
           <button
             onClick={() => router.push('/cart/compare')}
-            className="ml-auto flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-white text-black shadow-lg transition-transform hover:scale-105 active:scale-95"
+            className="ml-auto shrink-0 rounded-full bg-accent px-4 py-2 text-sm font-semibold text-black shadow-lg transition-transform hover:scale-105 active:scale-95"
           >
-            <Image src="/images/cart/move_cart.png" alt="장바구니로 이동" width={25} height={25} />
+            과정비교가기
           </button>
         </motion.div>
       )}

--- a/src/features/cart/components/compare-table/CartCompareSection.tsx
+++ b/src/features/cart/components/compare-table/CartCompareSection.tsx
@@ -132,7 +132,7 @@ export default function CartCompareSection() {
         <CardHeader className="pb-2 md:hidden">
           <CardTitle className="text-sm">과정 비교</CardTitle>
           <div className="text-muted-foreground text-xs">
-            장바구니에서 강의를 선택하여 비교하세요
+            AI 심층 비교 목록에서 강의를 선택하세요
           </div>
         </CardHeader>
         <CardContent className="space-y-3">

--- a/src/features/cart/components/compare-table/CartItemSidebar.tsx
+++ b/src/features/cart/components/compare-table/CartItemSidebar.tsx
@@ -4,7 +4,8 @@ import { useState } from 'react'
 
 import { motion, useReducedMotion, AnimatePresence } from 'framer-motion'
 import Image from 'next/image'
-import { FiChevronDown, FiChevronUp, FiShoppingCart } from 'react-icons/fi'
+import { FiChevronDown, FiChevronUp } from 'react-icons/fi'
+import { PiRobotDuotone } from 'react-icons/pi'
 
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import type { CartItem } from '@/features/cart/types/cart.type'
@@ -31,9 +32,9 @@ export function CartItemSidebar({ items, isLoading, isError, canUseItem, isAlrea
       {isLoading ? (
         <div className="text-muted-foreground text-sm">불러오는 중...</div>
       ) : isError ? (
-        <div className="text-muted-foreground text-sm">장바구니 목록을 불러오지 못했습니다.</div>
+        <div className="text-muted-foreground text-sm">AI 심층 비교 목록을 불러오지 못했습니다.</div>
       ) : items.length === 0 ? (
-        <div className="text-muted-foreground text-sm">장바구니가 비어있습니다.</div>
+        <div className="text-muted-foreground text-sm">AI 심층 비교 목록이 비어있습니다.</div>
       ) : (
         items.map(item => (
           <motion.div
@@ -99,8 +100,8 @@ export function CartItemSidebar({ items, isLoading, isError, canUseItem, isAlrea
           className="flex w-full items-center justify-between gap-4 p-4"
         >
           <div className="flex items-center gap-2 whitespace-nowrap">
-            <FiShoppingCart className="h-5 w-5 shrink-0 text-gray-500" />
-            <span className="text-base font-semibold">장바구니</span>
+            <PiRobotDuotone className="h-5 w-5 shrink-0 text-gray-500" />
+            <span className="text-base font-semibold">AI 심층 비교</span>
             {availableCount > 0 && (
               <span className="shrink-0 rounded-full bg-orange-100 px-2 py-0.5 text-xs font-medium text-orange-600">
                 {availableCount}개 선택 가능
@@ -145,8 +146,8 @@ export function CartItemSidebar({ items, isLoading, isError, canUseItem, isAlrea
           className="flex w-full items-center justify-between gap-4 p-4"
         >
           <div className="flex items-center gap-2 whitespace-nowrap">
-            <FiShoppingCart className="h-5 w-5 shrink-0 text-gray-500" />
-            <span className="text-base font-semibold">장바구니</span>
+            <PiRobotDuotone className="h-5 w-5 shrink-0 text-gray-500" />
+            <span className="text-base font-semibold">AI 심층 비교</span>
             {availableCount > 0 && (
               <span className="shrink-0 rounded-full bg-orange-100 px-2 py-0.5 text-xs font-medium text-orange-600">
                 {availableCount}개 선택 가능

--- a/src/features/lecture/components/detail/LectureSidebar.tsx
+++ b/src/features/lecture/components/detail/LectureSidebar.tsx
@@ -89,7 +89,7 @@ export default function LectureSidebar({ lecture }: Props) {
                 size="lg"
                 className="h-12 w-full rounded-xl border-gray-200 hover:bg-gray-50"
               >
-                장바구니
+                AI 심층 비교
               </AddToCartButton>
               <Button
                 variant="outline"


### PR DESCRIPTION
- 헤더 아이콘을 BsCart4에서 PiRobotDuotone으로 변경
- 헤더 tooltip "장바구니" → "AI 심층 비교"
- FloatingCart 버튼을 "과정비교가기" 텍스트로 변경
- CartItemSidebar 제목 "장바구니" → "AI 심층 비교"
- CartCompareSection 안내 문구 변경
- LectureSidebar 버튼 텍스트 변경
- LogoutDialog 메시지 변경