### PR TITLE
refactor: 중복 fetch 로직을 refetchLectures 함수로 추출

### DIFF
--- a/src/features/mypage/components/Personal/PersonalMain.tsx
+++ b/src/features/mypage/components/Personal/PersonalMain.tsx
@@ -71,6 +71,12 @@ export default function PersonalMain({ activeSection, openInfoModal, onOpenProdu
   // lectureId별 승인(버튼 라벨 전환용)
   const [approvedLectureIds, setApprovedLectureIds] = useState<Set<number>>(new Set())
 
+  // 강의 목록 새로고침 함수 (중복 로직 추출)
+  const refetchLectures = async () => {
+    const { data } = await api.get<CompletedLecture[]>('/mypage/completed-lectures')
+    setLectures(Array.isArray(data) ? data : [])
+  }
+
   // Create review modal state (ReviewForm 재사용)
   const [createOpen, setCreateOpen] = useState(false)
   const [createLectureId, setCreateLectureId] = useState<number | null>(null)
@@ -270,8 +276,7 @@ export default function PersonalMain({ activeSection, openInfoModal, onOpenProdu
 
       // 목록 갱신
       try {
-        const { data } = await api.get<CompletedLecture[]>('/mypage/completed-lectures')
-        setLectures(Array.isArray(data) ? data : [])
+        await refetchLectures()
         setCertImageOpen(false)
         setSelectedCertificate(null)
       } catch {
@@ -469,8 +474,7 @@ export default function PersonalMain({ activeSection, openInfoModal, onOpenProdu
                     try {
                       setLecturesLoading(true)
                       setLecturesError(null)
-                      const { data } = await api.get<CompletedLecture[]>('/mypage/completed-lectures')
-                      setLectures(Array.isArray(data) ? data : [])
+                      await refetchLectures()
                     } catch {
                       setLecturesError('강의 목록을 불러오지 못했습니다.')
                     } finally {
@@ -701,8 +705,7 @@ export default function PersonalMain({ activeSection, openInfoModal, onOpenProdu
                 // 목록 갱신
                 try {
                   setLecturesLoading(true)
-                  const { data } = await api.get<CompletedLecture[]>('/mypage/completed-lectures')
-                  setLectures(Array.isArray(data) ? data : [])
+                  await refetchLectures()
                 } finally {
                   setLecturesLoading(false)
                 }


### PR DESCRIPTION
## 📋 PR 요약

PersonalMain.tsx에서 중복된 강의 목록 fetch 로직을 `refetchLectures` 함수로 추출합니다.

## 🔗 관련 이슈

closes #189

## 📝 변경 사항

### refetchLectures 함수 추가
```typescript
const refetchLectures = async () => {
  const { data } = await api.get<CompletedLecture[]>('/mypage/completed-lectures')
  setLectures(Array.isArray(data) ? data : [])
}
```

### 중복 코드 제거
| 위치 | 변경 전 | 변경 후 |
|------|--------|--------|
| handleCertImageUpload | api.get + setLectures | await refetchLectures() |
| 재시도 버튼 onClick | api.get + setLectures | await refetchLectures() |
| onSaveSuccess | api.get + setLectures | await refetchLectures() |

## 💬 리뷰어에게 (선택)

- PR #186 리뷰에서 제안된 개선사항입니다.
- useEffect 내부는 cancelled 플래그를 사용한 race condition 방지가 필요하여 그대로 유지했습니다.

🤖 Generated with [Claude Code](https://claude.ai/code)