### PR TITLE
perf: 리뷰 상태 N+1 API 호출 제거

### DIFF
--- a/src/features/mypage/api/completedLectures.api.ts
+++ b/src/features/mypage/api/completedLectures.api.ts
@@ -1,4 +1,4 @@
-import { APPROVAL_STATUS, type ApprovalStatus } from '@/features/admin/types/approval.type'
+import { type ApprovalStatus } from '@/features/admin/types/approval.type'
 import { api } from '@/lib/axios'
 
 export type CertificateStatus = ApprovalStatus
@@ -15,51 +15,14 @@ export type CompletedLecture = {
   reviewId?: number
   certificateImageUrl?: string
   certificateStatus?: CertificateStatus
-}
-
-export type ReviewResponse = {
-  approvalStatus?: string
+  reviewStatus?: ReviewStatus
 }
 
 /**
  * 수료 강의 목록 조회
+ * 응답에 reviewStatus가 포함되어 있어 별도 API 호출 불필요
  */
 export async function getCompletedLectures(): Promise<CompletedLecture[]> {
   const { data } = await api.get<CompletedLecture[]>('/mypage/completed-lectures')
   return Array.isArray(data) ? data : []
-}
-
-/**
- * 특정 강의의 리뷰 상태 조회
- */
-export async function getReviewStatus(lectureId: number): Promise<ReviewStatus> {
-  try {
-    const { data } = await api.get<ReviewResponse>(`/mypage/completed-lectures/${lectureId}/review`)
-    const statusStr = String(data?.approvalStatus ?? '').toUpperCase()
-    if (statusStr === APPROVAL_STATUS.APPROVED) return APPROVAL_STATUS.APPROVED
-    if (statusStr === APPROVAL_STATUS.REJECTED) return APPROVAL_STATUS.REJECTED
-    return APPROVAL_STATUS.PENDING
-  } catch (error) {
-    console.error(`리뷰 상태 조회 실패 (lectureId: ${lectureId}):`, error)
-    return APPROVAL_STATUS.PENDING
-  }
-}
-
-/**
- * 여러 강의의 리뷰 상태를 병렬로 조회
- */
-export async function getReviewStatuses(
-  lectures: CompletedLecture[],
-): Promise<Map<number, ReviewStatus>> {
-  const targetLectures = lectures.filter(l => !l.canWriteReview)
-  if (targetLectures.length === 0) return new Map()
-
-  const results = await Promise.all(
-    targetLectures.map(async l => ({
-      lectureId: l.lectureId,
-      status: await getReviewStatus(l.lectureId),
-    })),
-  )
-
-  return new Map(results.map(r => [r.lectureId, r.status]))
 }

--- a/src/features/mypage/components/ActivitySummary.tsx
+++ b/src/features/mypage/components/ActivitySummary.tsx
@@ -7,10 +7,7 @@ import { LuAward, LuBadgeCheck, LuClipboardCheck, LuPencil } from 'react-icons/l
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { APPROVAL_STATUS } from '@/features/admin/types/approval.type'
-import {
-  useCompletedLecturesQuery,
-  useReviewStatusesQuery,
-} from '@/features/mypage/hooks/useCompletedLecturesQuery'
+import { useCompletedLecturesQuery } from '@/features/mypage/hooks/useCompletedLecturesQuery'
 
 import { useSurveyStatusQuery } from '../hooks/useSurvey'
 
@@ -21,24 +18,19 @@ type ActivitySummaryProps = {
 export function ActivitySummary({ onEditSurvey }: ActivitySummaryProps) {
   // React Query hooks - 캐싱으로 중복 호출 방지
   const { data: lectures, isLoading: lecturesLoading } = useCompletedLecturesQuery()
-  const { data: reviewStatuses, isLoading: reviewStatusesLoading } = useReviewStatusesQuery(lectures)
 
   // 설문 상태는 React Query로 관리 (모달에서 변경 시 자동 반영)
   const { data: surveyStatus, isLoading: surveyLoading } = useSurveyStatusQuery()
   const hasBasicSurvey = surveyStatus?.hasBasicSurvey ?? false
   const hasAptitudeTest = surveyStatus?.hasAptitudeTest ?? false
 
-  // 승인된 후기 수 계산
+  // 승인된 후기 수 계산 (응답의 reviewStatus 직접 사용)
   const approvedReviews = useMemo(() => {
-    if (!reviewStatuses) return 0
-    let count = 0
-    reviewStatuses.forEach(status => {
-      if (status === APPROVAL_STATUS.APPROVED) count++
-    })
-    return count
-  }, [reviewStatuses])
+    if (!lectures) return 0
+    return lectures.filter(l => l.reviewStatus === APPROVAL_STATUS.APPROVED).length
+  }, [lectures])
 
-  const loading = lecturesLoading || reviewStatusesLoading || surveyLoading
+  const loading = lecturesLoading || surveyLoading
 
   return (
     <Card className="bg-card">

--- a/src/features/mypage/components/ManagementSection.tsx
+++ b/src/features/mypage/components/ManagementSection.tsx
@@ -20,20 +20,14 @@ import {
 } from '@/features/admin/types/approval.type'
 import type { CompletedLecture } from '@/features/mypage/api/completedLectures.api'
 import { ReviewForm } from '@/features/mypage/components/review/ReviewForm'
-import {
-  completedLecturesQueryKey,
-  useCompletedLecturesQuery,
-  useReviewStatusesQuery,
-} from '@/features/mypage/hooks/useCompletedLecturesQuery'
+import { completedLecturesQueryKey, useCompletedLecturesQuery } from '@/features/mypage/hooks/useCompletedLecturesQuery'
 
 export function ReviewManagementSection() {
   const queryClient = useQueryClient()
 
   // React Query hooks - 캐싱으로 중복 호출 방지
-  const { data: lectures, isLoading: lecturesLoading } = useCompletedLecturesQuery()
-  const { data: reviewStatuses, isLoading: reviewStatusesLoading } = useReviewStatusesQuery(lectures)
-
-  const isLoading = lecturesLoading || reviewStatusesLoading
+  // reviewStatus가 응답에 포함되어 별도 API 호출 불필요
+  const { data: lectures, isLoading } = useCompletedLecturesQuery()
 
   // Edit review modal
   const [editOpen, setEditOpen] = useState(false)
@@ -55,21 +49,18 @@ export function ReviewManagementSection() {
   const [previewUrl, setPreviewUrl] = useState<string | null>(null)
   const [fullImageUrl, setFullImageUrl] = useState<string | null>(null)
 
-  const getStatusLabel = (lectureId: number, canWriteReview: boolean): string => {
-    if (canWriteReview) return '작성 가능'
-    const status = reviewStatuses?.get(lectureId)
-    return getApprovalStatusLabel(status)
+  const getStatusLabel = (lecture: CompletedLecture): string => {
+    if (lecture.canWriteReview) return '작성 가능'
+    return getApprovalStatusLabel(lecture.reviewStatus)
   }
 
-  const getStatusBadgeClass = (lectureId: number, canWriteReview: boolean): string => {
-    if (canWriteReview) return 'bg-gray-400 text-white'
-    const status = reviewStatuses?.get(lectureId)
-    return getApprovalStatusColor(status)
+  const getStatusBadgeClass = (lecture: CompletedLecture): string => {
+    if (lecture.canWriteReview) return 'bg-gray-400 text-white'
+    return getApprovalStatusColor(lecture.reviewStatus)
   }
 
-  const isReadOnly = (lectureId: number): boolean => {
-    const status = reviewStatuses?.get(lectureId)
-    return status === APPROVAL_STATUS.APPROVED || status === APPROVAL_STATUS.REJECTED
+  const isReadOnly = (lecture: CompletedLecture): boolean => {
+    return lecture.reviewStatus === APPROVAL_STATUS.APPROVED || lecture.reviewStatus === APPROVAL_STATUS.REJECTED
   }
 
   const handleFileSelect = (file: File) => {
@@ -156,9 +147,9 @@ export function ReviewManagementSection() {
                           </Badge>
                           <Badge
                             variant="secondary"
-                            className={`text-xs ${getStatusBadgeClass(l.lectureId, l.canWriteReview)}`}
+                            className={`text-xs ${getStatusBadgeClass(l)}`}
                           >
-                            {getStatusLabel(l.lectureId, l.canWriteReview)}
+                            {getStatusLabel(l)}
                           </Badge>
                         </div>
                       </TableCell>
@@ -172,9 +163,9 @@ export function ReviewManagementSection() {
                       <TableCell className="hidden sm:table-cell">
                         <Badge
                           variant="secondary"
-                          className={`text-xs ${getStatusBadgeClass(l.lectureId, l.canWriteReview)}`}
+                          className={`text-xs ${getStatusBadgeClass(l)}`}
                         >
-                          {getStatusLabel(l.lectureId, l.canWriteReview)}
+                          {getStatusLabel(l)}
                         </Badge>
                       </TableCell>
                       {/* 관리 버튼: 수료증 + 후기 */}
@@ -229,14 +220,14 @@ export function ReviewManagementSection() {
                                   onClick={() => {
                                     setSelectedReviewId(l.reviewId ?? null)
                                     setSelectedLectureId(l.lectureId)
-                                    setSelectedReviewReadOnly(isReadOnly(l.lectureId))
+                                    setSelectedReviewReadOnly(isReadOnly(l))
                                     setEditOpen(true)
                                   }}
                                 >
                                   <LuPencil className="h-4 w-4" />
                                 </Button>
                               </TooltipTrigger>
-                              <TooltipContent>{isReadOnly(l.lectureId) ? '리뷰 조회' : '리뷰 수정'}</TooltipContent>
+                              <TooltipContent>{isReadOnly(l) ? '리뷰 조회' : '리뷰 수정'}</TooltipContent>
                             </Tooltip>
                           )}
                         </div>

--- a/src/features/mypage/components/Personal/PersonalMain.tsx
+++ b/src/features/mypage/components/Personal/PersonalMain.tsx
@@ -13,7 +13,6 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import {
   APPROVAL_STATUS,
-  APPROVAL_STATUS_COLOR,
   getApprovalStatusLabel,
   canEditByStatus,
   type ApprovalStatus,
@@ -63,6 +62,7 @@ export default function PersonalMain({ activeSection, openInfoModal, onOpenProdu
     reviewId?: number
     certificateImageUrl?: string
     certificateStatus?: ApprovalStatus
+    reviewStatus?: ApprovalStatus
   }
 
   const [lectures, setLectures] = useState<CompletedLecture[] | null>(null)
@@ -74,9 +74,6 @@ export default function PersonalMain({ activeSection, openInfoModal, onOpenProdu
   const [selectedReviewId, setSelectedReviewId] = useState<number | null>(null)
   const [selectedLectureId, setSelectedLectureId] = useState<number | null>(null)
   const [selectedReviewReadOnly, setSelectedReviewReadOnly] = useState(false)
-
-  // lectureId별 승인(버튼 라벨 전환용)
-  const [approvedLectureIds, setApprovedLectureIds] = useState<Set<number>>(new Set())
 
   // 강의 목록 새로고침 함수 (중복 로직 추출)
   const refetchLectures = async () => {
@@ -162,69 +159,10 @@ export default function PersonalMain({ activeSection, openInfoModal, onOpenProdu
     }
   }, [activeSection])
 
-  useEffect(() => {
-    if (activeSection !== 'reviews') return
-    if (!lectures || lectures.length === 0) return
-
-    let cancelled = false
-
-    const parseApproved = (data: unknown): boolean => {
-      const approvalStatus = (data as { approvalStatus?: unknown })?.approvalStatus
-      if (typeof approvalStatus === 'string') {
-        return approvalStatus.toUpperCase() === APPROVAL_STATUS.APPROVED
-      }
-
-      const status =
-        (data as { status?: unknown; reviewStatus?: unknown })?.status ??
-        (data as { reviewStatus?: unknown })?.reviewStatus
-      const statusStr = typeof status === 'string' ? status : ''
-
-      const isApprovedBool =
-        (data as { isApproved?: unknown })?.isApproved === true || (data as { approved?: unknown })?.approved === true
-
-      return isApprovedBool || statusStr.toUpperCase() === APPROVAL_STATUS.APPROVED
-    }
-
-    const hydrateApproved = async () => {
-      const targetLectures = lectures.filter(l => !l.canWriteReview)
-      if (targetLectures.length === 0) return
-
-      try {
-        const results = await Promise.all(
-          targetLectures.map(async l => {
-            try {
-              const { data } = await api.get<unknown>(`/mypage/completed-lectures/${l.lectureId}/review`)
-              const rid = (data as { reviewId?: unknown })?.reviewId
-              return {
-                lectureId: l.lectureId,
-                reviewId: typeof rid === 'number' ? rid : Number(rid),
-                approved: parseApproved(data),
-              }
-            } catch {
-              return { lectureId: l.lectureId, reviewId: NaN, approved: false }
-            }
-          }),
-        )
-
-        if (cancelled) return
-        setApprovedLectureIds(prev => {
-          const next = new Set(prev)
-          for (const r of results) {
-            if (r.approved) next.add(r.lectureId)
-            else next.delete(r.lectureId)
-          }
-          return next
-        })
-      } catch {
-        // ignore
-      }
-    }
-
-    hydrateApproved()
-    return () => {
-      cancelled = true
-    }
-  }, [activeSection, lectures])
+  // 리뷰 승인 여부 확인 헬퍼 함수
+  const isReviewApproved = (lecture: CompletedLecture): boolean => {
+    return lecture.reviewStatus === APPROVAL_STATUS.APPROVED
+  }
 
   const formatDate = (iso?: string) => {
     if (!iso) return ''
@@ -512,7 +450,7 @@ export default function PersonalMain({ activeSection, openInfoModal, onOpenProdu
                               </Badge>
                             ) : (
                               <Badge className="rounded-full border-gray-200 bg-white text-gray-700" variant="outline">
-                                {approvedLectureIds.has(l.lectureId) ? '후기 승인' : '후기 완료'}
+                                {isReviewApproved(l) ? '후기 승인' : '후기 완료'}
                               </Badge>
                             )}
                           </div>
@@ -551,11 +489,11 @@ export default function PersonalMain({ activeSection, openInfoModal, onOpenProdu
                                 variant="ghost"
                                 size="icon"
                                 className="h-8 w-8"
-                                aria-label={approvedLectureIds.has(l.lectureId) ? '리뷰 조회' : '리뷰 수정'}
+                                aria-label={isReviewApproved(l) ? '리뷰 조회' : '리뷰 수정'}
                                 onClick={() => {
                                   setSelectedReviewId(l.reviewId ?? null)
                                   setSelectedLectureId(l.lectureId)
-                                  setSelectedReviewReadOnly(Boolean(approvedLectureIds.has(l.lectureId)))
+                                  setSelectedReviewReadOnly(Boolean(isReviewApproved(l)))
                                   setEditOpen(true)
                                 }}
                               >
@@ -579,7 +517,7 @@ export default function PersonalMain({ activeSection, openInfoModal, onOpenProdu
                           </Badge>
                         ) : (
                           <Badge className="rounded-full border-gray-200 bg-white text-gray-700" variant="outline">
-                            {approvedLectureIds.has(l.lectureId) ? '승인됨' : '작성완료'}
+                            {isReviewApproved(l) ? '승인됨' : '작성완료'}
                           </Badge>
                         )}
                       </TableCell>
@@ -635,7 +573,7 @@ export default function PersonalMain({ activeSection, openInfoModal, onOpenProdu
                                   onClick={() => {
                                     setSelectedReviewId(l.reviewId ?? null)
                                     setSelectedLectureId(l.lectureId)
-                                    setSelectedReviewReadOnly(Boolean(approvedLectureIds.has(l.lectureId)))
+                                    setSelectedReviewReadOnly(Boolean(isReviewApproved(l)))
                                     setEditOpen(true)
                                   }}
                                 >
@@ -643,7 +581,7 @@ export default function PersonalMain({ activeSection, openInfoModal, onOpenProdu
                                 </Button>
                               </TooltipTrigger>
                               <TooltipContent>
-                                {approvedLectureIds.has(l.lectureId) ? '리뷰 조회' : '리뷰 수정'}
+                                {isReviewApproved(l) ? '리뷰 조회' : '리뷰 수정'}
                               </TooltipContent>
                             </Tooltip>
                           )}

--- a/src/features/mypage/hooks/useCompletedLecturesQuery.ts
+++ b/src/features/mypage/hooks/useCompletedLecturesQuery.ts
@@ -2,12 +2,7 @@
 
 import { useQuery } from '@tanstack/react-query'
 
-import {
-  getCompletedLectures,
-  getReviewStatuses,
-  type CompletedLecture,
-  type ReviewStatus,
-} from '@/features/mypage/api/completedLectures.api'
+import { getCompletedLectures } from '@/features/mypage/api/completedLectures.api'
 import { useAuthStore } from '@/store/authStore'
 
 export const completedLecturesQueryKey = ['mypage', 'completedLectures'] as const
@@ -15,6 +10,7 @@ export const completedLecturesQueryKey = ['mypage', 'completedLectures'] as cons
 /**
  * 수료 강의 목록 조회 hook
  * React Query 캐싱으로 중복 API 호출 방지
+ * 응답에 reviewStatus가 포함되어 있어 별도 API 호출 불필요
  */
 export function useCompletedLecturesQuery() {
   const isLoggedIn = useAuthStore(state => state.isLoggedIn)
@@ -23,23 +19,5 @@ export function useCompletedLecturesQuery() {
     queryKey: completedLecturesQueryKey,
     queryFn: getCompletedLectures,
     enabled: isLoggedIn,
-  })
-}
-
-export const reviewStatusesQueryKey = (lectures: CompletedLecture[]) =>
-  ['mypage', 'reviewStatuses', lectures.map(l => l.lectureId).sort((a, b) => a - b).join(',')] as const
-
-/**
- * 리뷰 상태 조회 hook
- * 수료 강의 목록을 기반으로 각 강의의 리뷰 상태를 조회
- */
-export function useReviewStatusesQuery(lectures: CompletedLecture[] | undefined) {
-  const isLoggedIn = useAuthStore(state => state.isLoggedIn)
-  const validLectures = lectures ?? []
-
-  return useQuery({
-    queryKey: reviewStatusesQueryKey(validLectures),
-    queryFn: () => getReviewStatuses(validLectures),
-    enabled: isLoggedIn && validLectures.length > 0,
   })
 }

--- a/src/features/mypage/index.ts
+++ b/src/features/mypage/index.ts
@@ -1,21 +1,13 @@
 // API
 export {
   getCompletedLectures,
-  getReviewStatus,
-  getReviewStatuses,
   type CompletedLecture,
   type CertificateStatus,
   type ReviewStatus,
-  type ReviewResponse,
 } from './api/completedLectures.api'
 
 // Hooks
-export {
-  useCompletedLecturesQuery,
-  useReviewStatusesQuery,
-  completedLecturesQueryKey,
-  reviewStatusesQueryKey,
-} from './hooks/useCompletedLecturesQuery'
+export { useCompletedLecturesQuery, completedLecturesQueryKey } from './hooks/useCompletedLecturesQuery'
 
 // Components
 export { ActivitySummary } from './components/ActivitySummary'


### PR DESCRIPTION
## 📋 PR 요약

서버 API 변경(sw-campus/sw-campus-server#429)에 대응하여 N+1 API 호출 로직을 제거하고 `reviewStatus` 필드를 직접 사용하도록 수정합니다.

## 🔗 관련 이슈

closes #226

## 📝 변경 사항

### API 레이어
- `completedLectures.api.ts`: `reviewStatus` 필드 추가, N+1 API 함수 제거

### Hook 레이어
- `useCompletedLecturesQuery.ts`: N+1 hook 제거 (`useReviewStatusesQuery`)

### 컴포넌트
- `ActivitySummary.tsx`: `reviewStatus` 직접 사용
- `ManagementSection.tsx`: `reviewStatus` 직접 사용
- `PersonalMain.tsx`: N+1 로직 제거, `reviewStatus` 직접 사용

### Export 정리
- `index.ts`: 삭제된 함수/hook export 제거

## 💬 리뷰어에게 (선택)

- API 호출: N+1회 → 1회로 감소
- 코드 삭제량: 약 150줄 감소 (단순화)
- 서버 PR: sw-campus/sw-campus-server#430